### PR TITLE
TFS: Added cmdlets to create release definitions

### DIFF
--- a/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinition.ps1
@@ -39,7 +39,7 @@ function Get-TfsBuildDefinition
     )
     
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
-    $requestUrl += if ( $Port  -gt 0)
+    $requestUrl += if ( $Port -gt 0)
     {
         '{0}{1}/{2}/{3}/_apis/build/definitions' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
@@ -75,15 +75,17 @@ function Get-TfsBuildDefinition
     }
     catch
     {
+        if ($_.ErrorDetails.Message)
+        {
+            $errorDetails = $_.ErrorDetails.Message | ConvertFrom-Json
+            if ($errorDetails.typeKey -eq 'ProjectDoesNotExistWithNameException')
+            {
+                return $null
+            }
+        }
+        
         Write-Error -ErrorRecord $_
     }
     
-    if ($result.value)
-    {
-        return $result.value
-    }
-    elseif ($result)
-    {
-        return $result
-    }
+    return $result.value
 }

--- a/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinition.ps1
@@ -41,11 +41,16 @@ function Get-TfsBuildDefinition
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port  -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/build/definitions?api-version={4}' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/build/definitions' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/build/definitions?api-version={3}' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/build/definitions' -f $InstanceName, $CollectionName, $ProjectName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $requestParameters = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinitionTemplate.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Build/Get-TfsBuildDefinitionTemplate.ps1
@@ -38,11 +38,16 @@ function Get-TfsBuildDefinitionTemplate
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port  -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/build/definitions/templates?api-version={4}' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/build/definitions/templates' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/build/definitions/templates?api-version={3}' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/build/definitions/templates' -f $InstanceName, $CollectionName, $ProjectName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $requestParameters = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Build/New-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Build/New-TfsBuildDefinition.ps1
@@ -48,11 +48,16 @@ function New-TfsBuildDefinition
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/build/definitions?api-version={4}' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/build/definitions' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/build/definitions?api-version={3}' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/build/definitions' -f $InstanceName, $CollectionName, $ProjectName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $qparameters = Sync-Parameter -Command (Get-Command Get-TfsAgentQueue) -Parameters $PSBoundParameters

--- a/AutomatedLab.Common/TeamFoundation/Public/Build/New-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Build/New-TfsBuildDefinition.ps1
@@ -60,6 +60,15 @@ function New-TfsBuildDefinition
         $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
+    $exBuildParam = Sync-Parameter -Command (Get-Command Get-TfsBuildDefinition) -Parameters $PSBoundParameters
+    $exBuildParam.Remove('Version')
+    $existingBuild = Get-TfsBuildDefinition @exBuildParam
+    if ($existingBuild)
+    { 
+        Write-Verbose -Message ('Build definition {0} in {1} already exists.' -f $DefinitionName, $ProjectName);
+        return 
+    }
+
     $qparameters = Sync-Parameter -Command (Get-Command Get-TfsAgentQueue) -Parameters $PSBoundParameters
     $qparameters.Remove('ApiVersion') # preview-API is called
     $qparameters.ErrorAction = 'SilentlyContinue'
@@ -67,6 +76,7 @@ function New-TfsBuildDefinition
 
     if (-not $queue)
     {
+        Write-Verbose -Message ('No existing queue found for project {0}. Creating new queue.' -f $ProjectName)
         $parameters = Sync-Parameter -Command (Get-Command New-TfsAgentQueue) -Parameters $PSBoundParameters
         $parameters.Remove('ApiVersion') # preview-API is called
         $parameters.ErrorAction = 'Stop'
@@ -171,6 +181,7 @@ function New-TfsBuildDefinition
     try
     {
         $result = Invoke-RestMethod @requestParameters
+        Write-Verbose -Message ('New build definition {0} created for project {1}' -f $DefinitionName, $ProjectName)
     }
     catch
     {

--- a/AutomatedLab.Common/TeamFoundation/Public/Pools/Get-TfsAgentPool.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Pools/Get-TfsAgentPool.ps1
@@ -28,11 +28,16 @@ function Get-TfsAgentPool
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port  -gt 0)
     {
-        '{0}{1}/_apis/distributedtask/pools?api-version={2}' -f $InstanceName, ":$Port", $ApiVersion
+        '{0}{1}/_apis/distributedtask/pools' -f $InstanceName, ":$Port"
     }
     else
     {
-        '{0}/_apis/distributedtask/pools?api-version={1}' -f $InstanceName, $ApiVersion
+        '{0}/_apis/distributedtask/pools' -f $InstanceName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $requestParameters = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProcessTemplate.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProcessTemplate.ps1
@@ -33,11 +33,16 @@ function Get-TfsProcessTemplate
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ($Port -gt 0)
     {
-        '{0}{1}/{2}/_apis/process/processes?api-version={3}' -f $InstanceName, ":$Port", $CollectionName, $ApiVersion
+        '{0}{1}/{2}/_apis/process/processes' -f $InstanceName, ":$Port", $CollectionName
     }
     else
     {
-        '{0}/{1}/_apis/process/processes?api-version={2}' -f $InstanceName, $CollectionName, $ApiVersion
+        '{0}/{1}/_apis/process/processes' -f $InstanceName, $CollectionName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
     
     $requestParameters = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProject.ps1
@@ -69,6 +69,14 @@ function Get-TfsProject
     }
     catch
     {
+        if ($_.ErrorDetails.Message)
+        {
+            $errorDetails = $_.ErrorDetails.Message | ConvertFrom-Json
+            if ($errorDetails.typeKey -eq 'ProjectDoesNotExistWithNameException')
+            {
+                return $null
+            }
+        }
         Write-Error -ErrorRecord $_
     }
      

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/Get-TfsProject.ps1
@@ -36,11 +36,16 @@ function Get-TfsProject
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/_apis/projects{4}?api-version={3}' -f $InstanceName, ":$Port", $CollectionName, $ApiVersion, "/$ProjectName"
+        '{0}{1}/{2}/_apis/projects{3}' -f $InstanceName, ":$Port", $CollectionName, "/$ProjectName"
     }
     else
     {
-        '{0}/{1}/_apis/projects{3}?api-version={2}' -f $InstanceName, $CollectionName, $ApiVersion, "/$ProjectName"
+        '{0}/{1}/_apis/projects{2}' -f $InstanceName, $CollectionName, "/$ProjectName"
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
  
     $requestParameters = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/New-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/New-TfsProject.ps1
@@ -82,6 +82,7 @@ function New-TfsProject
     $projectParameters.ErrorAction = 'SilentlyContinue'
     if (Get-TfsProject @projectParameters)
     {
+        Write-Verbose -Message ('Project {0} already exists' -f $ProjectName)
         return
     }
 

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/New-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/New-TfsProject.ps1
@@ -59,11 +59,16 @@ function New-TfsProject
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/_apis/projects?api-version={3}' -f $InstanceName, ":$Port", $CollectionName, $ApiVersion
+        '{0}{1}/{2}/_apis/projects' -f $InstanceName, ":$Port", $CollectionName
     }
     else
     {
-        '{0}/{1}/_apis/projects?api-version={2}' -f $InstanceName, $CollectionName, $ApiVersion
+        '{0}/{1}/_apis/projects' -f $InstanceName, $CollectionName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     if ($PSCmdlet.ParameterSetName -like 'Name*')

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/Set-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/Set-TfsProject.ps1
@@ -43,11 +43,16 @@ function Set-TfsProject
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/_apis/projects/{4}?api-version={3}' -f $InstanceName, ":$Port", $CollectionName, $ApiVersion, $ProjectGuid
+        '{0}{1}/{2}/_apis/projects/{3}' -f $InstanceName, ":$Port", $CollectionName, $ProjectGuid
     }
     else
     {
-        '{0}/{1}/_apis/projects/{3}?api-version={2}' -f $InstanceName, $CollectionName, $ApiVersion, $ProjectGuid
+        '{0}/{1}/_apis/projects/{2}' -f $InstanceName, $CollectionName, $ProjectGuid
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $payload = @{

--- a/AutomatedLab.Common/TeamFoundation/Public/Projects/Set-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Projects/Set-TfsProject.ps1
@@ -80,6 +80,7 @@ function Set-TfsProject
     try
     {
         $result = Invoke-RestMethod @requestParameters
+        Write-Verbose ('Project {0} renamed to {1}' -f $ProjectGuid, $NewName)
     }
     catch
     {

--- a/AutomatedLab.Common/TeamFoundation/Public/Queue/Get-TfsAgentQueue.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Queue/Get-TfsAgentQueue.ps1
@@ -40,11 +40,16 @@ function Get-TfsAgentQueue
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/distributedtask/queues?api-version={4}' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/distributedtask/queues' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/distributedtask/queues?api-version={3}' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/distributedtask/queues' -f $InstanceName, $CollectionName, $ProjectName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     if ($QueueName)

--- a/AutomatedLab.Common/TeamFoundation/Public/Queue/Get-TfsAgentQueue.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Queue/Get-TfsAgentQueue.ps1
@@ -82,12 +82,5 @@ function Get-TfsAgentQueue
         Write-Error -ErrorRecord $_
     }
     
-    if ($result.value)
-    {
-        return $result.value
-    }
-    elseif ($result)
-    {
-        return $result
-    }
+    return $result.value
 }

--- a/AutomatedLab.Common/TeamFoundation/Public/Queue/New-TfsAgentQueue.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Queue/New-TfsAgentQueue.ps1
@@ -43,11 +43,16 @@ function New-TfsAgentQueue
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/distributedTask/queues?api-version={4}' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/distributedTask/queues' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/distributedTask/queues?api-version={3}' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/distributedTask/queues' -f $InstanceName, $CollectionName, $ProjectName
+    }
+    
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $poolParameter = Sync-Parameter -Command (Get-Command Get-TfsAgentPool) -Parameters $PSBoundParameters

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseDefinition.ps1
@@ -71,15 +71,17 @@ function Get-TfsReleaseDefinition
     }
     catch
     {
+        if ($_.ErrorDetails.Message)
+        {
+            $errorDetails = $_.ErrorDetails.Message | ConvertFrom-Json
+            if ($errorDetails.typeKey -eq 'ProjectDoesNotExistWithNameException')
+            {
+                return $null
+            }
+        }
+        
         Write-Error -ErrorRecord $_
     }
     
-    if ($result.value)
-    {
-        return $result.value
-    }
-    elseif ($result)
-    {
-        return $result
-    }
+    return $result.value
 }

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseDefinition.ps1
@@ -1,33 +1,35 @@
-function Get-TfsGitRepository
+function Get-TfsReleaseDefinition
 {
+    [CmdletBinding(DefaultParameterSetName = 'Cred')]
     param
     (
         [Parameter(Mandatory)]
         [string]
         $InstanceName,
 
-        [Parameter(Mandatory)]
+        [Parameter()]
         [string]
-        $CollectionName,
+        $CollectionName = 'DefaultCollection',
 
         [ValidateRange(1, 65535)]
         [uint32]
         $Port,
 
         [string]
-        $ApiVersion = '1.0',
+        $ApiVersion,
 
+        [Parameter(Mandatory)]
         [string]
         $ProjectName,
 
         [switch]
         $UseSsl,
 
-        [Parameter(ParameterSetName = 'Tfs')]
+        [Parameter(Mandatory, ParameterSetName = 'Cred')]
         [pscredential]
         $Credential,
         
-        [Parameter(ParameterSetName = 'Vsts')]
+        [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
         $PersonalAccessToken
     )
@@ -35,22 +37,23 @@ function Get-TfsGitRepository
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
     {
-        '{0}{1}/{2}/{3}/_apis/git/repositories' -f $InstanceName, ":$Port", $CollectionName, $ProjectName, $ApiVersion
+        '{0}{1}/{2}/{3}/_apis/release/definitions' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
     }
     else
     {
-        '{0}/{1}/{2}/_apis/git/repositories' -f $InstanceName, $CollectionName, $ProjectName, $ApiVersion
+        '{0}/{1}/{2}/_apis/release/definitions' -f $InstanceName, $CollectionName, $ProjectName
     }
-    
+
     if ($ApiVersion)
     {
         $requestUrl += '?api-version={0}' -f $ApiVersion
     }
 
     $requestParameters = @{
-        Uri         = $requestUrl
-        Method      = 'Get'
-        ErrorAction = 'Stop'
+        Uri             = $requestUrl
+        Method          = 'Get'
+        ErrorAction     = 'Stop'
+        UseBasicParsing = $true
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseStep.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/Get-TfsReleaseStep.ps1
@@ -1,0 +1,152 @@
+function Get-TfsReleaseStep
+{
+    [CmdletBinding(DefaultParameterSetName = 'Tfs')]
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $InstanceName,
+
+        [Parameter()]
+        [string]
+        $CollectionName = 'DefaultCollection',
+
+        [ValidateRange(1, 65535)]
+        [uint32]
+        $Port,
+
+        [Parameter(Mandatory, ParameterSetName = 'TfsName')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsName')]
+        [SupportsWildcards()]
+        [string]
+        $FriendlyName,
+
+        [Parameter(Mandatory, ParameterSetName = 'TfsHashtable')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsHashtable')]
+        [hashtable]
+        $FilterHashtable,
+
+        [Parameter(Mandatory, ParameterSetName = 'TfsScript')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsScript')]
+        [scriptblock]
+        $FilterScript,
+
+        [switch]
+        $UseSsl,
+
+        [Parameter(Mandatory, ParameterSetName = 'Tfs')]
+        [Parameter(Mandatory, ParameterSetName = 'TfsName')]
+        [Parameter(Mandatory, ParameterSetName = 'TfsHashtable')]
+        [Parameter(Mandatory, ParameterSetName = 'TfsScript')]
+        [pscredential]
+        $Credential,
+        
+        [Parameter(Mandatory, ParameterSetName = 'Vsts')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsName')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsHashtable')]
+        [Parameter(Mandatory, ParameterSetName = 'VstsScript')]
+        [string]
+        $PersonalAccessToken
+    )
+
+    $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
+    $requestUrl += if ( $Port -gt 0)
+    {
+        '{0}{1}/{2}/_apis/distributedtask/tasks' -f $InstanceName, ":$Port", $CollectionName
+    }
+    else
+    {
+        '{0}/{1}/_apis/distributedtask/tasks' -f $InstanceName, $CollectionName
+    }
+
+    $requestParameters = @{
+        Uri         = $requestUrl
+        Method      = 'Get'
+        ErrorAction = 'Stop'
+    }
+
+    if ($Credential)
+    {
+        $requestParameters.Credential = $Credential
+    }
+    else
+    {
+        $requestParameters.Headers = @{ Authorization = Get-TfsAccessTokenString -PersonalAccessToken $PersonalAccessToken }
+    }
+
+    try
+    {
+        $result = Invoke-RestMethod @requestParameters
+    }
+    catch
+    {
+        Write-Error -ErrorRecord $_
+    }
+    
+    $steps = if ($result.value)
+    {
+        $result.value | Where-Object -Property visibility -Contains 'Release'
+    }
+    elseif ($result)
+    {
+        $result | Where-Object -Property visibility -Contains 'Release'
+    }
+
+    if ($FriendlyName)
+    {
+        $steps = if ($FriendlyName -match '(\?|\*)')
+        {
+            $steps | Where-Object -Property friendlyName -like $FriendlyName
+        }
+        else
+        {
+            $steps | Where-Object -Property friendlyName -eq $FriendlyName
+        }
+    }
+
+    if ($FilterHashtable)
+    {
+        $steps = foreach ( $kvp in $FilterHashtable.GetEnumerator())
+        {
+            if ($kvp.Value -match '(\?|\*)')
+            {
+                $steps | Where-Object -Property $kvp.Key -like $kvp.Value
+            }
+            else
+            {
+                $steps | Where-Object -Property $kvp.Key -eq $kvp.Value    
+            }            
+        }
+    }
+
+    if ($FilterScript)
+    {
+        $steps = $steps | Where-Object -FilterScript $FilterScript
+    }
+
+    '@('
+    foreach ($step in $steps)
+    {
+        "
+        @{
+            enabled          = `$true
+            continueOnError  = `$false
+            alwaysRun        = `$false
+            timeoutInMinutes = 0
+            definitionType   = 'task'
+            version          = '*'
+            name             = 'YOUR OWN DISPLAY NAME HERE' # e.g. $($step.instanceNameFormat) or $($step.friendlyName)
+            taskid           = '$($step.id)'
+            inputs           = @{"
+        foreach ($input in $step.inputs)
+        {
+            $required = if ($input.required) {$true}else {$false}
+            "`t`t`t`t{0} = 'VALUE' # Type: {1}, Default: {2}, Mandatory: {3}" -f $input.name, $input.type, $input.defaultValue, $required
+        }
+        '
+            }
+        }
+        '
+    }
+    ')'
+}

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
@@ -136,7 +136,7 @@ function New-TfsReleaseDefinition
                         "workflowTasks"   = $ReleaseTasks
                         "deploymentInput" = @{
                             "demands"               = @() 
-                            "queueId"               = 1 
+                            "queueId"               = $queue.id 
                             "enableAccessToken"     = $false 
                             "skipArtifactsDownload" = $false 
                             "timeoutInMinutes"      = 0

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
@@ -1,0 +1,253 @@
+function New-TfsReleaseDefinition
+{
+    [CmdletBinding(DefaultParameterSetName = 'Cred')]
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $InstanceName,
+
+        [Parameter()]
+        [string]
+        $CollectionName = 'DefaultCollection',
+
+        [ValidateRange(1, 65535)]
+        [uint32]
+        $Port,
+
+        [string]
+        $ApiVersion = '3.0-preview.3',
+
+        [Parameter(Mandatory)]
+        [string]
+        $ProjectName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ReleaseName,
+
+        [hashtable[]]
+        $ReleaseTasks,
+
+        [switch]
+        $UseSsl,
+
+        [Parameter(Mandatory, ParameterSetName = 'Cred')]
+        [pscredential]
+        $Credential,
+        
+        [Parameter(Mandatory, ParameterSetName = 'Pat')]
+        [string]
+        $PersonalAccessToken
+    )
+
+    $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
+    $requestUrl += if ( $Port -gt 0)
+    {
+        '{0}{1}/{2}/{3}/_apis/release/definitions' -f $InstanceName, ":$Port", $CollectionName, $ProjectName
+    }
+    else
+    {
+        '{0}/{1}/{2}/_apis/release/definitions' -f $InstanceName, $CollectionName, $ProjectName
+    }
+
+    if ($ApiVersion)
+    {
+        $requestUrl += '?api-version={0}' -f $ApiVersion
+    }
+
+    $exReleaseParam = Sync-Parameter -Command (Get-Command Get-TfsReleaseDefinition) -Parameters $PSBoundParameters
+    $exReleaseParam.Remove('Version')
+    $existingRelease = Get-TfsReleaseDefinition @exReleaseParam
+    if ($existingRelease) { return }
+
+    $qparameters = Sync-Parameter -Command (Get-Command Get-TfsAgentQueue) -Parameters $PSBoundParameters
+    $qparameters.Remove('ApiVersion') # preview-API is called
+    $qparameters.ErrorAction = 'SilentlyContinue'
+    $queue = Get-TfsAgentQueue @qparameters | Select-Object -First 1
+
+    if (-not $queue)
+    {
+        $parameters = Sync-Parameter -Command (Get-Command New-TfsAgentQueue) -Parameters $PSBoundParameters
+        $parameters.Remove('ApiVersion') # preview-API is called
+        $parameters.ErrorAction = 'Stop'
+        $qparameters.ErrorAction = 'Stop'
+        try
+        {
+            New-TfsAgentQueue @parameters
+            $queue = Get-TfsAgentQueue @qparameters | Select-Object -First 1
+        }
+        catch
+        {
+            Write-Error -ErrorRecord $_
+        }
+    }
+
+    $projectParameters = Sync-Parameter -Command (Get-Command Get-TfsProject) -Parameters $PSBoundParameters
+    $projectParameters.ErrorAction = 'Stop'
+    
+    try
+    {
+        $project = Get-TfsProject @projectParameters
+    }
+    catch
+    {
+        Write-Error -ErrorRecord $_
+    }
+
+    $buildParameters = Sync-Parameter -Command (Get-Command Get-TfsBuildDefinition) -Parameters $PSBoundParameters
+    $buildParameters.ErrorAction = 'Stop'
+
+    try
+    {
+        $build = Get-TfsBuildDefinition @buildParameters
+    }
+    catch
+    {
+        Write-Error -ErrorRecord $_
+    }
+
+    $payload = @{
+        "id"                = 0 
+        "name"              = $ReleaseName
+        "comment"           = $null 
+        "createdOn"         = "2018-03-20T09:10:08.964Z" 
+        "createdBy"         = $null 
+        "modifiedBy"        = $null 
+        "modifiedOn"        = $null 
+        "environments"      = @(
+            @{
+                "id"                      = -656 
+                "name"                    = "Environment" 
+                "rank"                    = 1 
+                "deployStep"              = @{
+                    "id"    = 0 
+                    "tasks" = @()
+                } 
+                "deployPhases"            = @(
+                    @{
+                        "name"            = "Run on agent" 
+                        "phaseType"       = 1 
+                        "rank"            = 1 
+                        "workflowTasks"   = $ReleaseTasks
+                        "deploymentInput" = @{
+                            "demands"               = @() 
+                            "queueId"               = 1 
+                            "enableAccessToken"     = $false 
+                            "skipArtifactsDownload" = $false 
+                            "timeoutInMinutes"      = 0
+                        } 
+                        "controlOptions"  = @{
+                            "alwaysRun"       = $false 
+                            "continueOnError" = $false 
+                            "enabled"         = $true
+                        }
+                    }
+                ) 
+                "queueId"                 = $queue.id 
+                "demands"                 = @() 
+                "conditions"              = @(
+                    @{
+                        "name"          = "ReleaseStarted" 
+                        "conditionType" = 1 
+                        "value"         = ""
+                    }
+                ) 
+                "environmentOptions"      = @{
+                    "emailNotificationType" = "OnlyOnFailure" 
+                    "emailRecipients"       = "release.environment.owner;release.creator" 
+                    "skipArtifactsDownload" = $false 
+                    "timeoutInMinutes"      = 0 
+                    "enableAccessToken"     = $false
+                } 
+                "executionPolicy"         = @{
+                    "concurrencyCount" = 0 
+                    "queueDepthCount"  = 0
+                } 
+                "releaseId"               = $null 
+                "definitionEnvironmentId" = $null 
+                "preDeployApprovals"      = @{
+                    "approvals"       = @(
+                        @{
+                            "rank"             = 1 
+                            "isAutomated"      = $true
+                            "isNotificationOn" = $false 
+                            "id"               = 0
+                        }
+                    ) 
+                    "approvalOptions" = $null
+                } 
+                "postDeployApprovals"     = @{
+                    "approvals"       = @(
+                        @{
+                            "rank"             = 1 
+                            "isAutomated"      = $true 
+                            "isNotificationOn" = $false 
+                            "id"               = 0
+                        }
+                    ) 
+                    "approvalOptions" = $null
+                } 
+                "schedules"               = @() 
+                "retentionPolicy"         = @{
+                    "daysToKeep"     = 30 
+                    "releasesToKeep" = 3 
+                    "retainBuild"    = $true
+                }
+            }
+        ) 
+        "artifacts"         = @(
+            @{
+                "id"                  = 0 
+                "definitionReference" = @{
+                    "project"    = @{
+                        "id"   = $project.id
+                        "name" = $project.name
+                    } 
+                    "definition" = @{
+                        "id"   = $build.id
+                        "name" = $build.name
+                    }
+                } 
+                "alias"               = $build.name
+                "type"                = "Build" 
+                "artifactTypeName"    = "Build" 
+                "sourceId"            = "" 
+                "isPrimary"           = $true
+            }
+        )  
+        "triggers"          = @(
+            @{
+                "triggerType"   = 1 
+                "artifactAlias" = $build.name
+            }
+        ) 
+        "releaseNameFormat" = 'Release-$(rev:r)'
+    }
+
+    $requestParameters = @{
+        Uri         = $requestUrl
+        Method      = 'Post'
+        ContentType = 'application/json'
+        Body        = ($payload | ConvertTo-Json -Depth 42)
+        ErrorAction = 'Stop'
+    }
+
+    if ($Credential)
+    {
+        $requestParameters.Credential = $Credential
+    }
+    else
+    {
+        $requestParameters.Headers = @{ Authorization = Get-TfsAccessTokenString -PersonalAccessToken $PersonalAccessToken }
+    }
+
+    try
+    {
+        $result = Invoke-RestMethod @requestParameters
+    }
+    catch
+    {
+        Write-Error -ErrorRecord $_
+    }
+}

--- a/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Release/New-TfsReleaseDefinition.ps1
@@ -59,7 +59,11 @@ function New-TfsReleaseDefinition
     $exReleaseParam = Sync-Parameter -Command (Get-Command Get-TfsReleaseDefinition) -Parameters $PSBoundParameters
     $exReleaseParam.Remove('Version')
     $existingRelease = Get-TfsReleaseDefinition @exReleaseParam
-    if ($existingRelease) { return }
+    if ($existingRelease)
+    {
+        Write-Verbose -Message ('Release definition {0} in {1} already exists.' -f $ReleaseName, $ProjectName);
+        return 
+    }
 
     $qparameters = Sync-Parameter -Command (Get-Command Get-TfsAgentQueue) -Parameters $PSBoundParameters
     $qparameters.Remove('ApiVersion') # preview-API is called
@@ -245,6 +249,7 @@ function New-TfsReleaseDefinition
     try
     {
         $result = Invoke-RestMethod @requestParameters
+        Write-Verbose -Message ('New release definition {0} created for project {1}' -f $ReleaseName, $ProjectName)
     }
     catch
     {

--- a/AutomatedLab.Common/TeamFoundation/Public/Repository/Get-TfsGitRepository.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Repository/Get-TfsGitRepository.ps1
@@ -68,15 +68,17 @@ function Get-TfsGitRepository
     }
     catch
     {
+        if ($_.ErrorDetails.Message)
+        {
+            $errorDetails = $_.ErrorDetails.Message | ConvertFrom-Json
+            if ($errorDetails.typeKey -eq 'ProjectDoesNotExistWithNameException')
+            {
+                return $null
+            }
+        }
+        
         Write-Error -ErrorRecord $_
     }
     
-    if ($result.value)
-    {
-        return $result.value
-    }
-    elseif ($result)
-    {
-        return $result
-    }
+    return $result.value
 }


### PR DESCRIPTION
Added new cmdlets:
- New-TfsReleaseDefinition (Create new definition if it does not exist)
- Get-TfsReleaseDefinition (List existing definitions)
- Get-TfsReleaseStep (List all available tasks valid for a release definition)

Updated usage of ApiVersion to make it accept empty values
Added verbose output to Set/New cmdlets