### PR TITLE
Win7/2008R2 compatibility (fixes #42)

### DIFF
--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -207,7 +207,7 @@ function Install-SoftwarePackage
     if ($result.Process.ExitCode -ne 0 `
     -and $result.Process.ExitCode -ne 3010 `
     -and $result.Process.ExitCode -ne $null `
-    -and $result.Process.ExitCode -notin $ExpectedReturnCodes)
+    -and $ExpectedReturnCodes -notcontains $result.Process.ExitCode )
     {
         throw (New-Object System.ComponentModel.Win32Exception($result.Process.ExitCode))
     }

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -13,7 +13,7 @@ function Install-SoftwarePackage
 
         [int[]]$ExpectedReturnCodes,
 
-        [pscredential]$Credential
+        [system.management.automation.pscredential]$Credential
     )
     
     #region New-InstallProcess


### PR DESCRIPTION
Changed -notin to -notcontains in Install-SoftwarePackage
Specified full type name instead of type accelerator for pscredential