### PR TITLE
Made ALCommon Core compatible

### DIFF
--- a/AutomatedLab.Common/AutomatedLab.Common.psd1
+++ b/AutomatedLab.Common/AutomatedLab.Common.psd1
@@ -18,6 +18,8 @@
 
     CLRVersion             = '4.0'
 
+    CompatiblePSEditions   = @('Desktop','Core')
+
     FunctionsToExport      = '*'
 
     RequiredModules        = @('newtonsoft.json')

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -14,35 +14,7 @@ function Install-SoftwarePackage
         [int[]]$ExpectedReturnCodes,
 
         [system.management.automation.pscredential]$Credential
-    )
-
-    Add-Type -TypeDefinition @'
-namespace AutomatedLab.Common
-{
-    using System;
-
-    public class Win32Exception : System.ComponentModel.Win32Exception
-    {
-        public new int ErrorCode { get; set; }
-
-        public Win32Exception(int error) : base(error)
-        {
-            ErrorCode = error;
-        }
-
-        public Win32Exception(string message) : base(message)
-        { }
-
-        public Win32Exception(int error, string message)  : base(error, message)
-        {
-            ErrorCode = error;
-        }
-
-        public Win32Exception(string message , Exception innerException) : base(message, innerException)
-        { }
-    }
-}
-'@
+    )    
     
     #region New-InstallProcess
     function New-InstallProcess

--- a/AutomatedLab.Common/Common/Public/New-RunspacePool.ps1
+++ b/AutomatedLab.Common/Common/Public/New-RunspacePool.ps1
@@ -31,7 +31,11 @@ function New-RunspacePool
         Write-Verbose -Message "Creating new runspace pool. Maximum Runspaces: $ThrottleLimit, ApartmentState: $ApartmentState, Variables: $($Variable.Count)"
         $pool = New-Variable -Name "ALCommonRunspacePool_$($ThrottleLimit)_$($ApartmentState)" -Scope Global -Value $([runspacefactory]::CreateRunspacePool($InitialSessionState)) -PassThru
         [void] $($pool.Value.SetMaxRunspaces($ThrottleLimit))
-        $pool.Value.ApartmentState = $ApartmentState
+
+        if ($PSEdition -eq 'Desktop')
+        {
+            $pool.Value.ApartmentState = $ApartmentState
+        }
     }
         
     $pool.Value

--- a/AutomatedLab.Common/Common/Public/Send-ModuleToPsSession.ps1
+++ b/AutomatedLab.Common/Common/Public/Send-ModuleToPsSession.ps1
@@ -59,7 +59,6 @@ function Send-ModuleToPSSession
 
     begin
     {
-        Write-LogFunctionEntry
         $isCalledRecursivly = (Get-PSCallStack | Where-Object Command -eq $MyInvocation.InvocationName | Measure-Object | Select-Object -ExpandProperty Count) -gt 1
     }
     
@@ -186,6 +185,5 @@ function Send-ModuleToPSSession
     
     end
     {
-        Write-LogFunctionExit
     }
 }

--- a/AutomatedLab.Common/Common/Types/Gpo.ps1
+++ b/AutomatedLab.Common/Common/Types/Gpo.ps1
@@ -738,7 +738,7 @@ namespace GPO
 }
 '@
 
-if ($PSVersionTable.PSEdition -eq 'Core') 
+if ($PSEdition -eq 'Core') 
 { 
     Write-Verbose -Message 'Skipping import of GPO type on PS Core'
     return 

--- a/AutomatedLab.Common/Common/Types/Gpo.ps1
+++ b/AutomatedLab.Common/Common/Types/Gpo.ps1
@@ -738,4 +738,10 @@ namespace GPO
 }
 '@
 
+if ($PSVersionTable.PSEdition -eq 'Core') 
+{ 
+    Write-Verbose -Message 'Skipping import of GPO type on PS Core'
+    return 
+}
+
 Add-Type -TypeDefinition $gpoType -IgnoreWarnings

--- a/AutomatedLab.Common/Common/Types/Win32Exception.ps1
+++ b/AutomatedLab.Common/Common/Types/Win32Exception.ps1
@@ -1,0 +1,27 @@
+Add-Type -TypeDefinition @'
+namespace AutomatedLab.Common
+{
+    using System;
+
+    public class Win32Exception : System.ComponentModel.Win32Exception
+    {
+        public new int ErrorCode { get; set; }
+
+        public Win32Exception(int error) : base(error)
+        {
+            ErrorCode = error;
+        }
+
+        public Win32Exception(string message) : base(message)
+        { }
+
+        public Win32Exception(int error, string message)  : base(error, message)
+        {
+            ErrorCode = error;
+        }
+
+        public Win32Exception(string message , Exception innerException) : base(message, innerException)
+        { }
+    }
+}
+'@

--- a/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
+++ b/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
@@ -7,6 +7,12 @@ function Get-DscConfigurationImportedResource
         [Parameter(Mandatory, ParameterSetName = 'ByName')]
         [string]$Name
     )
+
+    if ($PSEdition -eq 'Core')
+    {
+        Write-Warning -Message 'Get-DscConfigurationImportedResource is not compatible with PowerShell Core.'
+        return
+    }
     
     $modules = New-Object System.Collections.ArrayList
 

--- a/AutomatedLab.Common/PkiHelper/Public/Enable-AutoEnrollment.ps1
+++ b/AutomatedLab.Common/PkiHelper/Public/Enable-AutoEnrollment.ps1
@@ -7,7 +7,13 @@ function Enable-AutoEnrollment
     )
     
     Write-Verbose -Message "Computer: '$Computer'"
-    Write-Verbose -Message "Computer: '$UserOrCodeSigning'"    
+    Write-Verbose -Message "Computer: '$UserOrCodeSigning'"
+
+    if ($PSVersionTable.PSEdition -eq 'Core') 
+    { 
+        Write-Warning -Message 'Cannot execute Enable-AutoEnrollment on PowerShell Core!'
+        return 
+    }
     
     if ($Computer)
     {

--- a/AutomatedLab.Common/PkiHelper/Public/Enable-AutoEnrollment.ps1
+++ b/AutomatedLab.Common/PkiHelper/Public/Enable-AutoEnrollment.ps1
@@ -9,7 +9,7 @@ function Enable-AutoEnrollment
     Write-Verbose -Message "Computer: '$Computer'"
     Write-Verbose -Message "Computer: '$UserOrCodeSigning'"
 
-    if ($PSVersionTable.PSEdition -eq 'Core') 
+    if ($PSEdition -eq 'Core') 
     { 
         Write-Warning -Message 'Cannot execute Enable-AutoEnrollment on PowerShell Core!'
         return 

--- a/AutomatedLab.Common/PkiHelper/Public/Request-Certificate.ps1
+++ b/AutomatedLab.Common/PkiHelper/Public/Request-Certificate.ps1
@@ -105,8 +105,7 @@ szOID_PKIX_KP_CLIENT_AUTH = "1.3.6.1.5.5.7.3.2"
     Copy-Item -Path $certFile -Destination c:\cert.cer -Force
     Copy-Item -Path $infFile -Destination c:\request.inf -Force
 
-    $certPrint = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
-    $certPrint.Import('C:\cert.cer')
+    $certPrint = [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromCertFile('C:\cert.cer')
     $certPrint
 
     Remove-Item -Path $infFile, $requestFile, $certFile, $rspFile, 'C:\cert.cer' -Force


### PR DESCRIPTION
CompatiblePSEditions set to Core and Desktop.
Incompatible type GPO and incompatible Cmdlet Enable-AutoEnrollment will be skipped. Enable-AutoEnrollment will generate a visible warning when used. The type is just silently ignored.