### PR TITLE
Adding cast to 'X509Certificate2'

### DIFF
--- a/AutomatedLab.Common/PkiHelper/Public/Request-Certificate.ps1
+++ b/AutomatedLab.Common/PkiHelper/Public/Request-Certificate.ps1
@@ -105,7 +105,7 @@ szOID_PKIX_KP_CLIENT_AUTH = "1.3.6.1.5.5.7.3.2"
     Copy-Item -Path $certFile -Destination c:\cert.cer -Force
     Copy-Item -Path $infFile -Destination c:\request.inf -Force
 
-    $certPrint = [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromCertFile('C:\cert.cer')
+    $certPrint = [System.Security.Cryptography.X509Certificates.X509Certificate2][System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromCertFile('C:\cert.cer')
     $certPrint
 
     Remove-Item -Path $infFile, $requestFile, $certFile, $rspFile, 'C:\cert.cer' -Force


### PR DESCRIPTION
For some reason a cast is required now. The method 'CreateFromCertFile' does no longer return a 'System.Security.Cryptography.X509Certificates.X509Certificate2' but a 'System.Security.Cryptography.X509Certificates.X509Certificate'. The X509Certificate2 object is missing most of the important information.