### PR TITLE
Certificate handling PSCore

### DIFF
--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsAgentPool.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsAgentPool.ps1
@@ -30,8 +30,16 @@ function Get-TfsAgentPool
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port  -gt 0)
@@ -53,6 +61,11 @@ function Get-TfsAgentPool
         Method          = 'Get'
         ErrorAction     = 'Stop'
         UseBasicParsing = $true
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsAgentQueue.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsAgentQueue.ps1
@@ -34,8 +34,16 @@ function Get-TfsAgentQueue
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -71,6 +79,11 @@ function Get-TfsAgentQueue
     else
     {
         $requestParameters.Headers = @{ Authorization = Get-TfsAccessTokenString -PersonalAccessToken $PersonalAccessToken }
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     try

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildDefinition.ps1
@@ -35,8 +35,16 @@ function Get-TfsBuildDefinition
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
     
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -58,6 +66,11 @@ function Get-TfsBuildDefinition
         Method          = 'Get'
         ErrorAction     = 'Stop'
         UseBasicParsing = $true
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildDefinitionTemplate.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildDefinitionTemplate.ps1
@@ -32,8 +32,16 @@ function Get-TfsBuildDefinitionTemplate
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port  -gt 0)
@@ -55,6 +63,11 @@ function Get-TfsBuildDefinitionTemplate
         Method          = 'Get'
         ErrorAction     = 'Stop'
         UseBasicParsing = $true
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildStep.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsBuildStep.ps1
@@ -46,8 +46,16 @@ function Get-TfsBuildStep
         [Parameter(Mandatory, ParameterSetName = 'VstsHashtable')]
         [Parameter(Mandatory, ParameterSetName = 'VstsScript')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -63,6 +71,11 @@ function Get-TfsBuildStep
         Uri         = $requestUrl
         Method      = 'Get'
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsGitRepository.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsGitRepository.ps1
@@ -29,8 +29,16 @@ function Get-TfsGitRepository
         
         [Parameter(ParameterSetName = 'Vsts')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -51,6 +59,11 @@ function Get-TfsGitRepository
         Uri         = $requestUrl
         Method      = 'Get'
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsProcessTemplate.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsProcessTemplate.ps1
@@ -27,8 +27,16 @@ function Get-TfsProcessTemplate
         
         [Parameter(Mandatory, ParameterSetName = 'Vsts')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ($Port -gt 0)
@@ -48,6 +56,11 @@ function Get-TfsProcessTemplate
     $requestParameters = @{
         Uri    = $requestUrl
         Method = 'Get'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ( $Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsProject.ps1
@@ -30,8 +30,16 @@ function Get-TfsProject
          
         [Parameter(ParameterSetName = 'Vsts')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
  
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -52,6 +60,11 @@ function Get-TfsProject
         Uri         = $requestUrl
         Method      = 'Get'
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
  
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsReleaseDefinition.ps1
@@ -31,8 +31,16 @@ function Get-TfsReleaseDefinition
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -54,6 +62,11 @@ function Get-TfsReleaseDefinition
         Method          = 'Get'
         ErrorAction     = 'Stop'
         UseBasicParsing = $true
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Get-TfsReleaseStep.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Get-TfsReleaseStep.ps1
@@ -46,8 +46,16 @@ function Get-TfsReleaseStep
         [Parameter(Mandatory, ParameterSetName = 'VstsHashtable')]
         [Parameter(Mandatory, ParameterSetName = 'VstsScript')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -63,6 +71,11 @@ function Get-TfsReleaseStep
         Uri         = $requestUrl
         Method      = 'Get'
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/New-TfsAgentQueue.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/New-TfsAgentQueue.ps1
@@ -34,8 +34,16 @@ function New-TfsAgentQueue
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $existingQueue = Get-TfsAgentQueue @PSBoundParameters
     if ($existingQueue) { return $existingQueue }
@@ -75,6 +83,11 @@ function New-TfsAgentQueue
         ContentType = 'application/json'
         Body        = ($payload | ConvertTo-Json)
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/New-TfsBuildDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/New-TfsBuildDefinition.ps1
@@ -51,8 +51,16 @@ function New-TfsBuildDefinition
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ($Port -gt 0)
@@ -269,6 +277,11 @@ function New-TfsBuildDefinition
         ContentType = 'application/json'
         Body        = ($buildDefinition | ConvertTo-Json -Depth 42)
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/New-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/New-TfsProject.ps1
@@ -53,8 +53,16 @@ function New-TfsProject
         $PersonalAccessToken,
 
         [timespan]
-        $Timeout = (New-TimeSpan -Seconds 30)
+        $Timeout = (New-TimeSpan -Seconds 30),
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -105,6 +113,11 @@ function New-TfsProject
         ContentType = 'application/json'
         Body        = ($payload | ConvertTo-Json)
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/New-TfsReleaseDefinition.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/New-TfsReleaseDefinition.ps1
@@ -41,8 +41,16 @@ function New-TfsReleaseDefinition
         
         [Parameter(Mandatory, ParameterSetName = 'Pat')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -243,6 +251,11 @@ function New-TfsReleaseDefinition
         ContentType = 'application/json'
         Body        = ($payload | ConvertTo-Json -Depth 42)
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/AutomatedLab.Common/TeamFoundation/Public/Set-TfsProject.ps1
+++ b/AutomatedLab.Common/TeamFoundation/Public/Set-TfsProject.ps1
@@ -37,8 +37,16 @@ function Set-TfsProject
         
         [Parameter(ParameterSetName = 'Vsts')]
         [string]
-        $PersonalAccessToken
+        $PersonalAccessToken,
+
+        [switch]
+        $SkipCertificateCheck
     )
+
+    if ($SkipCertificateCheck.IsPresent)
+    {
+        $null = [ServerCertificateValidationCallback]::Ignore()
+    }
 
     $requestUrl = if ($UseSsl) {'https://' } else {'http://'}
     $requestUrl += if ( $Port -gt 0)
@@ -66,6 +74,11 @@ function Set-TfsProject
         ContentType = 'application/json'
         Body        = ($payload | ConvertTo-Json)
         ErrorAction = 'Stop'
+    }
+
+    if ($PSEdition -eq 'Core' -and (Get-Command -Name Invoke-RestMethod).Parameters.ContainsKey('SkipCertificateCheck'))
+    {
+        $requestParameters.SkipCertificateCheck = $SkipCertificateCheck.IsPresent
     }
 
     if ($Credential)

--- a/Help/en-us/Get-TfsAgentPool.md
+++ b/Help/en-us/Get-TfsAgentPool.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,13 @@ Gets the TFS/VSTS agent pool
 ### Cred
 ```
 Get-TfsAgentPool -InstanceName <String> [-CollectionName <String>] [-PoolName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-ApiVersion <String>] [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Pat
 ```
 Get-TfsAgentPool -InstanceName <String> [-CollectionName <String>] [-PoolName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-ApiVersion <String>] [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 ```
 
 ### -CollectionName
-{{ Fill CollectionName Description }}
+The collection name
 
 ```yaml
 Type: String
@@ -167,10 +167,25 @@ Accept wildcard characters: False
 ```
 
 ### -PoolName
-{{ Fill PoolName Description }}
+The agent pool
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/Help/en-us/Get-TfsAgentQueue.md
+++ b/Help/en-us/Get-TfsAgentQueue.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,15 @@ Get the agent queue of a project
 ### Cred
 ```
 Get-TfsAgentQueue -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- -ProjectName <String> [-QueueName <String>] [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ -ProjectName <String> [-QueueName <String>] [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### Pat
 ```
 Get-TfsAgentQueue -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- -ProjectName <String> [-QueueName <String>] [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ -ProjectName <String> [-QueueName <String>] [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -179,6 +181,21 @@ Accept wildcard characters: False
 
 ### -UseSsl
 Indicates that SSL should be used
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
 
 ```yaml
 Type: SwitchParameter

--- a/Help/en-us/Get-TfsBuildDefinition.md
+++ b/Help/en-us/Get-TfsBuildDefinition.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -16,14 +16,14 @@ Gets all build definitions for a project
 ```
 Get-TfsBuildDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> [-QueueName <String>] [-UseSsl] -Credential <PSCredential>
- [<CommonParameters>]
+ [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Pat
 ```
 Get-TfsBuildDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> [-QueueName <String>] [-UseSsl] -PersonalAccessToken <String>
- [<CommonParameters>]
+ [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -238,6 +238,21 @@ Parameter Sets: Pat
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Help/en-us/Get-TfsBuildDefinitionTemplate.md
+++ b/Help/en-us/Get-TfsBuildDefinitionTemplate.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,15 @@ Gets all build definition templates
 ### Cred (Default)
 ```
 Get-TfsBuildDefinitionTemplate -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### Pat
 ```
 Get-TfsBuildDefinitionTemplate -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -291,6 +293,21 @@ Parameter Sets: Pat
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Help/en-us/Get-TfsBuildStep.md
+++ b/Help/en-us/Get-TfsBuildStep.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,49 +15,50 @@ Gets all available build steps
 ### Tfs (Default)
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-UseSsl]
- -Credential <PSCredential> [<CommonParameters>]
+ -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsName
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FriendlyName <String>
- [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### TfsName
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FriendlyName <String>
- [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsHashtable
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterHashtable <Hashtable> [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ -FilterHashtable <Hashtable> [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### TfsHashtable
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterHashtable <Hashtable> [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ -FilterHashtable <Hashtable> [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsScript
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FilterScript <ScriptBlock>
- [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### TfsScript
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FilterScript <ScriptBlock>
- [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Get-TfsBuildStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-UseSsl]
- -PersonalAccessToken <String> [<CommonParameters>]
+ -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -234,6 +235,21 @@ Parameter Sets: VstsScript, TfsScript
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Help/en-us/Get-TfsGitRepository.md
+++ b/Help/en-us/Get-TfsGitRepository.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,13 @@ Gets a project's repository
 ### Tfs
 ```
 Get-TfsGitRepository -InstanceName <String> -CollectionName <String> [-Port <UInt32>] [-ApiVersion <String>]
- [-ProjectName <String>] [-UseSsl] [-Credential <PSCredential>] [<CommonParameters>]
+ [-ProjectName <String>] [-UseSsl] [-Credential <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Get-TfsGitRepository -InstanceName <String> -CollectionName <String> [-Port <UInt32>] [-ApiVersion <String>]
- [-ProjectName <String>] [-UseSsl] [-PersonalAccessToken <String>] [<CommonParameters>]
+ [-ProjectName <String>] [-UseSsl] [-PersonalAccessToken <String>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -151,6 +151,21 @@ The VSTS access token as returned by Get-TfsAccessTokenString
 ```yaml
 Type: String
 Parameter Sets: Vsts
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/Help/en-us/Get-TfsProcessTemplate.md
+++ b/Help/en-us/Get-TfsProcessTemplate.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,13 @@ Gets all process templates
 ### Tfs
 ```
 Get-TfsProcessTemplate -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-ApiVersion <String>] [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Get-TfsProcessTemplate -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-ApiVersion <String>] [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -140,6 +140,21 @@ Parameter Sets: Vsts
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Help/en-us/Get-TfsProject.md
+++ b/Help/en-us/Get-TfsProject.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,13 @@ Gets projects
 ### Tfs
 ```
 Get-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- [-ProjectName <String>] [-UseSsl] [-Credential <PSCredential>] [<CommonParameters>]
+ [-ProjectName <String>] [-UseSsl] [-Credential <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Get-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- [-ProjectName <String>] [-UseSsl] [-PersonalAccessToken <String>] [<CommonParameters>]
+ [-ProjectName <String>] [-UseSsl] [-PersonalAccessToken <String>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -152,6 +152,21 @@ The VSTS access token as returned by Get-TfsAccessTokenString
 ```yaml
 Type: String
 Parameter Sets: Vsts
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/Help/en-us/Get-TfsReleaseDefinition.md
+++ b/Help/en-us/Get-TfsReleaseDefinition.md
@@ -16,13 +16,15 @@ Get one or more TFS/Azure DevOps Release Definitions
 ### Cred (Default)
 ```
 Get-TfsReleaseDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### Pat
 ```
 Get-TfsReleaseDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-ApiVersion <String>] -ProjectName <String> [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -148,6 +150,21 @@ Accept wildcard characters: False
 
 ### -UseSsl
 Indicates if SSL should be used to connect
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
 
 ```yaml
 Type: SwitchParameter

--- a/Help/en-us/Get-TfsReleaseStep.md
+++ b/Help/en-us/Get-TfsReleaseStep.md
@@ -15,49 +15,51 @@ Get all possible release steps
 ### Tfs (Default)
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-UseSsl]
- -Credential <PSCredential> [<CommonParameters>]
+ -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsName
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FriendlyName <String>
- [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### TfsName
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] -FriendlyName <String>
- [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsHashtable
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterHashtable <Hashtable> [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ -FilterHashtable <Hashtable> [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### TfsHashtable
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterHashtable <Hashtable> [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ -FilterHashtable <Hashtable> [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### VstsScript
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterScript <ScriptBlock> [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ -FilterScript <ScriptBlock> [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### TfsScript
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
- -FilterScript <ScriptBlock> [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ -FilterScript <ScriptBlock> [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Get-TfsReleaseStep -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-UseSsl]
- -PersonalAccessToken <String> [<CommonParameters>]
+ -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -203,6 +205,21 @@ Accept wildcard characters: False
 
 ### -UseSsl
 Indicates if SSL should be used
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
 
 ```yaml
 Type: SwitchParameter

--- a/Help/en-us/New-TfsAgentQueue.md
+++ b/Help/en-us/New-TfsAgentQueue.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -15,13 +15,15 @@ Create a new agent queue for your project
 ### Cred
 ```
 New-TfsAgentQueue -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- -ProjectName <String> [-UseSsl] [-QueueName <String>] -Credential <PSCredential> [<CommonParameters>]
+ -ProjectName <String> [-UseSsl] [-QueueName <String>] -Credential <PSCredential> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### Pat
 ```
 New-TfsAgentQueue -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
- -ProjectName <String> [-UseSsl] [-QueueName <String>] -PersonalAccessToken <String> [<CommonParameters>]
+ -ProjectName <String> [-UseSsl] [-QueueName <String>] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -162,6 +164,21 @@ Accept wildcard characters: False
 
 ### -UseSsl
 Indicates that SSL should be used
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
 
 ```yaml
 Type: SwitchParameter

--- a/Help/en-us/New-TfsBuildDefinition.md
+++ b/Help/en-us/New-TfsBuildDefinition.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -17,7 +17,7 @@ Create a new build definition for your project
 New-TfsBuildDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> -DefinitionName <String> [-QueueName <String>]
  [-BuildTasks <Hashtable[]>] [-Phases <Hashtable[]>] [-CiTriggerRefs <String[]>] [-Variables <Hashtable>]
- [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Pat
@@ -25,7 +25,7 @@ New-TfsBuildDefinition -InstanceName <String> [-CollectionName <String>] [-Port 
 New-TfsBuildDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> -DefinitionName <String> [-QueueName <String>]
  [-BuildTasks <Hashtable[]>] [-Phases <Hashtable[]>] [-CiTriggerRefs <String[]>] [-Variables <Hashtable>]
- [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -283,6 +283,21 @@ Accept wildcard characters: False
 
 ```yaml
 Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/Help/en-us/New-TfsProject.md
+++ b/Help/en-us/New-TfsProject.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -16,28 +16,28 @@ Create a new team project
 ```
 New-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectName <String> [-ProjectDescription <String>] [-SourceControlType <Object>] -TemplateName <String>
- [-UseSsl] -Credential <PSCredential> [-Timeout <TimeSpan>] [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-Timeout <TimeSpan>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### GuidCred
 ```
 New-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectName <String> [-ProjectDescription <String>] [-SourceControlType <Object>] -TemplateGuid <Guid>
- [-UseSsl] -Credential <PSCredential> [-Timeout <TimeSpan>] [<CommonParameters>]
+ [-UseSsl] -Credential <PSCredential> [-Timeout <TimeSpan>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### GuidPat
 ```
 New-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectName <String> [-ProjectDescription <String>] [-SourceControlType <Object>] -TemplateGuid <Guid>
- [-UseSsl] -PersonalAccessToken <String> [-Timeout <TimeSpan>] [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-Timeout <TimeSpan>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### NamePat
 ```
 New-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectName <String> [-ProjectDescription <String>] [-SourceControlType <Object>] -TemplateName <String>
- [-UseSsl] -PersonalAccessToken <String> [-Timeout <TimeSpan>] [<CommonParameters>]
+ [-UseSsl] -PersonalAccessToken <String> [-Timeout <TimeSpan>] [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -247,6 +247,21 @@ Parameter Sets: GuidPat, NamePat
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Help/en-us/New-TfsReleaseDefinition.md
+++ b/Help/en-us/New-TfsReleaseDefinition.md
@@ -16,14 +16,16 @@ Create a new release definition
 ```
 New-TfsReleaseDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> -ReleaseName <String> [-ReleaseTasks <Hashtable[]>]
- [-Environments <Hashtable[]>] [-UseSsl] -Credential <PSCredential> [<CommonParameters>]
+ [-Environments <Hashtable[]>] [-UseSsl] -Credential <PSCredential> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ### Pat
 ```
 New-TfsReleaseDefinition -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>]
  [-ApiVersion <String>] -ProjectName <String> -ReleaseName <String> [-ReleaseTasks <Hashtable[]>]
- [-Environments <Hashtable[]>] [-UseSsl] -PersonalAccessToken <String> [<CommonParameters>]
+ [-Environments <Hashtable[]>] [-UseSsl] -PersonalAccessToken <String> [-SkipCertificateCheck]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -213,6 +215,21 @@ Accept wildcard characters: False
 
 ### -UseSsl
 Indicates if SSL should be used
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
 
 ```yaml
 Type: SwitchParameter

--- a/Help/en-us/Set-TfsProject.md
+++ b/Help/en-us/Set-TfsProject.md
@@ -1,5 +1,5 @@
 ---
-external help file: AutomatedLab.Common-Help.xml
+external help file: AutomatedLab.Common-help.xml
 Module Name: AutomatedLab.Common
 online version:
 schema: 2.0.0
@@ -16,14 +16,14 @@ Change an existing team project's name and description
 ```
 Set-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectGuid <String> [-NewName <String>] [-NewDescription <String>] [-UseSsl] [-Credential <PSCredential>]
- [<CommonParameters>]
+ [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ### Vsts
 ```
 Set-TfsProject -InstanceName <String> [-CollectionName <String>] [-Port <UInt32>] [-ApiVersion <String>]
  -ProjectGuid <String> [-NewName <String>] [-NewDescription <String>] [-UseSsl] [-PersonalAccessToken <String>]
- [<CommonParameters>]
+ [-SkipCertificateCheck] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -183,6 +183,21 @@ The VSTS access token as returned by Get-TfsAccessTokenString
 ```yaml
 Type: String
 Parameter Sets: Vsts
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip certificate validation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
 Aliases:
 
 Required: False


### PR DESCRIPTION
In case the parameter exists, will use the new SkipCertificateCheck parameter. For older versions of PS Core or for Windows PowerShell will still use [ServerCertificateValidationCallback]::Ignore()