### PR TITLE
Sending modules now also to old versions or Linux

### DIFF
--- a/AutomatedLab.Common/AutomatedLab.Common.psd1
+++ b/AutomatedLab.Common/AutomatedLab.Common.psd1
@@ -22,7 +22,7 @@
 
     FunctionsToExport      = '*'
 
-    RequiredModules        = @('newtonsoft.json')
+    RequiredModules        = @('newtonsoft.json', 'PSFileTransfer')
 
     CmdletsToExport        = '*'
 

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -100,7 +100,7 @@ function Install-SoftwarePackage
         
         $tempRemoteFolder = [System.IO.Path]::GetTempFileName()
         Remove-Item -Path $tempRemoteFolder
-        mkdir -Path $tempRemoteFolder
+        New-Item -ItemType Directory -Path $tempRemoteFolder
         expand.exe -F:* $Path $tempRemoteFolder
         
         $cabFile = (Get-ChildItem -Path $tempRemoteFolder\*.cab -Exclude WSUSSCAN.cab).FullName

--- a/Build.ps1
+++ b/Build.ps1
@@ -48,7 +48,7 @@
 # Grab nuget bits, install modules, set build variables, start build.
 Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
 
-Resolve-Module PlatyPS, Psake, PSDeploy, Pester, BuildHelpers, PSScriptAnalyzer, newtonsoft.json
+Resolve-Module PlatyPS, Psake, PSDeploy, Pester, BuildHelpers, PSScriptAnalyzer, newtonsoft.json, PSFileTransfer, PSFramework
 
 Set-BuildEnvironment
 

--- a/Help/en-us/Send-ModuleToPSSession.md
+++ b/Help/en-us/Send-ModuleToPSSession.md
@@ -15,8 +15,8 @@ Send an entire module to a remote session
 
 ```
 Send-ModuleToPSSession [-Module] <PSModuleInfo> [-Session] <PSSession[]> [-Scope <String>]
- [-IncludeDependencies] [-Move] [-Encrypt] [-NoWriteBuffer] [-Verify] [-NoClobber] [-MaxBufferSize <UInt32>]
- [<CommonParameters>]
+ [-IncludeDependencies] [-Move] [-Encrypt] [-NoWriteBuffer] [-Verify] [-Force] [-NoClobber]
+ [-MaxBufferSize <UInt32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -185,14 +185,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+Indicates that the module should always be transmitted regardless of the version
+that already exists on the remote
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
+
 ## NOTES
 
 ## RELATED LINKS

--- a/Library/.build/post.ps1
+++ b/Library/.build/post.ps1
@@ -12,12 +12,12 @@ $fullClr = Join-Path -Path $path -ChildPath net462
 
 if (-not (Test-Path $destination\lib\core))
 {
-	$null = mkdir $destination\lib\core -Force
+	$null = New-Item -ItemType Directory $destination\lib\core -Force
 }
 
 if (-not (Test-Path $destination\lib\full))
 {
-	$null = mkdir $destination\lib\full -Force
+	$null = New-Item -ItemType Directory $destination\lib\full -Force
 }
 
 robocopy $coreClr $destination\lib\core *.dll /R:15 /W:5


### PR DESCRIPTION
Requires change to PSFileTransfer, which uses mkdir, a reserved command in Linux. Took this opportunity to remove ALL aliases in https://github.com/AutomatedLab/AutomatedLab/pull/675

Fixes #68 , tested with Exchange 2013 and PowerShell Workshop lab, in PS Core and Windows PowerShell. Linux change tested with CentOS and Ubuntu machines and SSH PSSessions. Paths on Linux are well documented.