### PR TITLE
Linux and macOS implemented for Test-IsAdministrator

### DIFF
--- a/AutomatedLab.Common/Common/Public/Test-IsAdministrator.ps1
+++ b/AutomatedLab.Common/Common/Public/Test-IsAdministrator.ps1
@@ -4,6 +4,16 @@ function Test-IsAdministrator
     [CmdletBinding()]
     param ()
     
-    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
-    (New-Object -TypeName Security.Principal.WindowsPrincipal -ArgumentList $currentUser).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    if ($IsLinux -or $IsMacOS)
+    {
+        # If sudo-ing or logged on as root, returns user ID 0
+        $idCmd = (Get-Command -Name id).Source
+        [int64] $idResult = & $idCmd -u
+        $idResult -eq 0
+    }
+    else
+    {
+        $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+        (New-Object -TypeName Security.Principal.WindowsPrincipal -ArgumentList $currentUser).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    }
 }


### PR DESCRIPTION
Checking for user ID 0, either obtained through sudo or by logging on as the root user