### PR TITLE
Explicit check for ApartmentState (Fixes #81)

### DIFF
--- a/AutomatedLab.Common/Common/Public/Get-RunspacePool.ps1
+++ b/AutomatedLab.Common/Common/Public/Get-RunspacePool.ps1
@@ -13,7 +13,7 @@ function Get-RunspacePool
         $ApartmentState
     )
 
-    $pools = $(Get-Variable -Name ALCommonRunspacePool_* -ErrorAction SilentlyContinue).Value
+    $pools = $(Get-Variable -Name ALCommonRunspacePool_* -Scope Script -ErrorAction SilentlyContinue).Value
 
     if ($ThrottleLimit)
     {

--- a/AutomatedLab.Common/Common/Public/New-RunspacePool.ps1
+++ b/AutomatedLab.Common/Common/Public/New-RunspacePool.ps1
@@ -17,7 +17,7 @@ function New-RunspacePool
         $Variable
     )
 
-    $pool = Get-Variable -Name "ALCommonRunspacePool_$($ThrottleLimit)_$($ApartmentState)" -Scope Global -ErrorAction SilentlyContinue
+    $pool = Get-Variable -Name "ALCommonRunspacePool_$($ThrottleLimit)_$($ApartmentState)" -Scope Script -ErrorAction SilentlyContinue
     $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
 
     foreach ($var in $Variable)
@@ -29,7 +29,7 @@ function New-RunspacePool
     if (-not ($pool))
     {
         Write-Verbose -Message "Creating new runspace pool. Maximum Runspaces: $ThrottleLimit, ApartmentState: $ApartmentState, Variables: $($Variable.Count)"
-        $pool = New-Variable -Name "ALCommonRunspacePool_$($ThrottleLimit)_$($ApartmentState)" -Scope Global -Value $([runspacefactory]::CreateRunspacePool($InitialSessionState)) -PassThru
+        $pool = New-Variable -Name "ALCommonRunspacePool_$($ThrottleLimit)_$($ApartmentState)" -Scope Script -Value $([runspacefactory]::CreateRunspacePool($InitialSessionState)) -PassThru
         [void] $($pool.Value.SetMaxRunspaces($ThrottleLimit))
 
         if ($PSEdition -eq 'Desktop')

--- a/AutomatedLab.Common/Common/Public/Remove-RunspacePool.ps1
+++ b/AutomatedLab.Common/Common/Public/Remove-RunspacePool.ps1
@@ -15,12 +15,13 @@ function Remove-RunspacePool
             if ($PSCmdlet.ShouldProcess($pool.InstanceId, 'Closing runspace pool'))
             {
                 $max = $pool.GetMaxRunspaces()
-                $state = if ($pool.ApartmentState) { $pool.ApartmentState } else {'Unknown'}
+                $state = if ($null -ne $pool.ApartmentState) { $pool.ApartmentState } else {'Unknown'}
 
                 $pool.Close()
                 $pool.Dispose()
 
-                Remove-Variable -Name "ALCommonRunspacePool_$($max)_$($state)" -Scope Global -ErrorAction SilentlyContinue
+                Write-Verbose -Message "Attempting to remove ALCommonRunspacePool_$($max)_$($state)"
+                Remove-Variable -Name "ALCommonRunspacePool_$($max)_$($state)" -Scope Script -ErrorAction SilentlyContinue
             }
         }
     }


### PR DESCRIPTION
Also changed the variable scope from global to script. Fixes #81 where a runspace pool would not always be closed. The reason was that the if statement ```if($pool.ApartmentState)``` did not evaluate properly, even though data was returned.