### PR TITLE
Fixing scoping issues

### DIFF
--- a/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
+++ b/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
@@ -4,8 +4,8 @@ function Get-DscConfigurationImportedResource
         [Parameter(Mandatory, ParameterSetName = 'ByFile')]
         [string]$FilePath,
         
-        [Parameter(Mandatory, ParameterSetName = 'ByName')]
-        [string]$Name
+        [Parameter(Mandatory, ParameterSetName = 'ByConfiguration')]
+        [System.Management.Automation.ConfigurationInfo]$Configuration
     )
 
     if ($PSEdition -eq 'Core')
@@ -16,9 +16,9 @@ function Get-DscConfigurationImportedResource
     
     $modules = New-Object System.Collections.ArrayList
 
-    if ($Name)
+    if ($Configuration)
     {
-        $ast = (Get-Command -Name $Name).ScriptBlock.Ast
+        $ast = $Configuration.ScriptBlock.Ast
         $FilePath = $ast.FindAll( { $args[0] -is [System.Management.Automation.Language.ScriptBlockAst] }, $true)[0].Extent.File
         if (-not $FilePath)
         {
@@ -31,10 +31,10 @@ function Get-DscConfigurationImportedResource
     
     $configurations = $ast.FindAll( { $args[0] -is [System.Management.Automation.Language.ConfigurationDefinitionAst] }, $true)
     Write-Verbose "Script knwos about $($configurations.Count) configurations"
-    foreach ($configuration in $configurations)
+    foreach ($c in $configurations)
     {
-        $importCmds = $configuration.Body.ScriptBlock.FindAll( { $args[0].Value -eq 'Import-DscResource' -and $args[0] -is [System.Management.Automation.Language.StringConstantExpressionAst] }, $true)
-        Write-Verbose "Configuration $($configuration.InstanceName) knows about $($importCmds.Count) Import-DscResource commands"
+        $importCmds = $c.Body.ScriptBlock.FindAll( { $args[0].Value -eq 'Import-DscResource' -and $args[0] -is [System.Management.Automation.Language.StringConstantExpressionAst] }, $true)
+        Write-Verbose "Configuration $($c.InstanceName) knows about $($importCmds.Count) Import-DscResource commands"
     
         foreach ($importCmd in $importCmds)
         {

--- a/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
+++ b/AutomatedLab.Common/DscHelper/Public/Get-DscConfigurationImportedResource.ps1
@@ -7,12 +7,6 @@ function Get-DscConfigurationImportedResource
         [Parameter(Mandatory, ParameterSetName = 'ByConfiguration')]
         [System.Management.Automation.ConfigurationInfo]$Configuration
     )
-
-    if ($PSEdition -eq 'Core')
-    {
-        Write-Warning -Message 'Get-DscConfigurationImportedResource is not compatible with PowerShell Core.'
-        return
-    }
     
     $modules = New-Object System.Collections.ArrayList
 

--- a/Help/en-us/Get-DscConfigurationImportedResource.md
+++ b/Help/en-us/Get-DscConfigurationImportedResource.md
@@ -17,9 +17,9 @@ Retrieve all imported resource modules from a DSC configuration
 Get-DscConfigurationImportedResource -FilePath <String> [<CommonParameters>]
 ```
 
-### ByName
+### ByConfiguration
 ```
-Get-DscConfigurationImportedResource -Name <String> [<CommonParameters>]
+Get-DscConfigurationImportedResource -Configuration <System.Management.Automation.ConfigurationInfo> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,7 +47,7 @@ configuration stuff
 '@ | Set-Content .\ConfigurationFile.ps1
 .\ConfigurationFile.ps1
 
-Get-DscConfigurationImportedResource -Name stuff
+Get-DscConfigurationImportedResource -Configuration (Get-Command -Name stuff)
 ```
 
 Returns "nx"
@@ -69,12 +69,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Name
-The name of a configuration that has already been imported
+### -Configuration
+A configuration that has already been imported an can be received using Get-Command
 
 ```yaml
 Type: String
-Parameter Sets: ByName
+Parameter Sets: ByConfiguration
 Aliases:
 
 Required: True

--- a/Help/en-us/Get-DscConfigurationImportedResource.md
+++ b/Help/en-us/Get-DscConfigurationImportedResource.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 A configuration that has already been imported an can be received using Get-Command
 
 ```yaml
-Type: String
+Type: System.Management.Automation.ConfigurationInfo
 Parameter Sets: ByConfiguration
 Aliases:
 

--- a/Help/en-us/Get-DscConfigurationImportedResource.md
+++ b/Help/en-us/Get-DscConfigurationImportedResource.md
@@ -73,7 +73,7 @@ Accept wildcard characters: False
 A configuration that has already been imported an can be received using Get-Command
 
 ```yaml
-Type: System.Management.Automation.ConfigurationInfo
+Type: ConfigurationInfo
 Parameter Sets: ByConfiguration
 Aliases:
 


### PR DESCRIPTION
This change is required to fix AutomatedLab/AutomatedLab#561. 'Get-DscConfigurationImportedResource' does not longer accept a name of a configuration but a ConfigurationInfo object.