### PR TITLE
The parameter conflicts when adding a variable named 'Path'

### DIFF
--- a/AutomatedLab.Common/Common/Public/Add-VariableToPSSession.ps1
+++ b/AutomatedLab.Common/Common/Public/Add-VariableToPSSession.ps1
@@ -34,8 +34,8 @@ function Add-VariableToPSSession
 
         $scriptBlock = 
         {
-            param([string]$Path, [object]$Value)
-            $null = Set-Item -Path Variable:\$Path -Value $Value
+            param([string]$_AL_Path, [object]$Value)
+            $null = Set-Item -Path Variable:\$_AL_Path -Value $Value
         }
     }
 


### PR DESCRIPTION
The parameter conflicts when adding a variable named 'Path'. The new name of the parameter should be unique enough to prevent this in the future.