### PR TITLE
Improved exception handling in 'Test-Port'

### DIFF
--- a/AutomatedLab.Common/NetworkHelper/Public/Test-Port.ps1
+++ b/AutomatedLab.Common/NetworkHelper/Public/Test-Port.ps1
@@ -54,7 +54,6 @@ function Test-Port
                     {
                         $tcpClient.Close()
                         $sw.Stop()
-                        Write-Verbose 'Connection Timeout'
 
                         $result.Open = $false
                         $result.Notes = 'Connection to Port Timed Out'
@@ -62,11 +61,18 @@ function Test-Port
                     }
                     else
                     {
-                        [void]$tcpClient.EndConnect($connect)
-                        $tcpClient.Close()
-                        $sw.Stop()
+                        try
+                        {
+                            [void]$tcpClient.EndConnect($connect)
+                            $tcpClient.Close()
+                            $sw.Stop()
 
-                        $result.Open = $true
+                            $result.Open = $true
+                        }
+                        catch
+                        {
+                            $result.Open = $false
+                        }
                     }
 
                     $result.ResponseTime = $sw.ElapsedMilliseconds
@@ -109,7 +115,7 @@ function Test-Port
                         $result.Open = $false
                         $result.Notes = 'Unable to verify if port is open or if host is unavailable.'
                     }
-                    finally
+                   finally
                     {
                         $udpClient.Close()
                         $result.ResponseTime = $sw.ElapsedMilliseconds
@@ -128,4 +134,4 @@ function Test-Port
     {
         $report 
     }
-}
+} 


### PR DESCRIPTION
Sometimes, 'Test-Port' throws an error like this:

```
Test-Port : Exception calling "EndConnect" with "1" argument(s): "Object reference not set to an instance of an object."
At C:\Program Files\WindowsPowerShell\Modules\AutomatedLab\5.32.273\AutomatedLabRemoting.psm1:211 char:29
+ ... $portTest = Test-Port -ComputerName $param.ComputerName -Port $param. ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Test-Port], MethodInvocationException
    + FullyQualifiedErrorId : NullReferenceException,Test-Port
```

After adding the error handling, the real problem comes to the surface:

```
New-LabPSSession : [Morph51-DCS001] Connecting to remote server Morph51-DCS001 failed with the following error message : Access is denied. For more information, see the about_Remote_Troubleshooting Help topic.
At C:\Program Files\WindowsPowerShell\Modules\PSFileTransfer\5.32.273\PSFileTransfer.psm1:510 char:28
+ ...  $session = New-LabPSSession -ComputerName $machine -IgnoreAzureLabSo ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OpenError: (System.Manageme....RemoteRunspace:RemoteRunspace) [Write-Error], PSRemotingTransportException
    + FullyQualifiedErrorId : AccessDenied,PSSessionOpenFailed
```

