### PR TITLE
Core compatibility

### DIFF
--- a/AutomatedLab.Common/Common/Public/Send-ModuleToPsSession.ps1
+++ b/AutomatedLab.Common/Common/Public/Send-ModuleToPsSession.ps1
@@ -124,7 +124,10 @@ function Send-ModuleToPSSession
 
         foreach ($s in $Session)
         {
-            $sessionVersion = Invoke-Command -Session $s -ScriptBlock {$PSVersionTable.PSVersion}
+            [version]$sessionVersion = Invoke-Command -Session $s -ScriptBlock {
+                if ($PSEdition -eq 'core') {return ('{0}.{1}.{2}' -f $PSVersionTable.PSVersion.Major,$PSVersionTable.PSVersion.Minor,$PSVersionTable.PSVersion.Patch)}
+                $PSVersionTable.PSVersion   
+            }
 
             if ($Local:Module.PowerShellVersion -gt $sessionVersion)
             {
@@ -137,7 +140,7 @@ function Send-ModuleToPSSession
                 Invoke-Command -Session $s -ScriptBlock {
                     $destination = if (-not $IsLinux -and -not $IsMacOs)
                     {
-                        if ($PSVersionTable.PSVersion -ge ([version]::new(4,0)))
+                        if ($PSVersionTable.PSVersion.Major -ge 4)
                         {
                             Join-Path -Path ([System.Environment]::GetFolderPath('ProgramFiles')) -ChildPath WindowsPowerShell\Modules
                         }


### PR DESCRIPTION
Send-ModuleToPSSession will now work with PS Core sessions as well. Since semver versions cannot be cast into versions, I return a string if on Core and the version if we are connected to Windows PowerShell. Both are cast into version to compare.