### PR TITLE
Replacing UNC path with drive letter on Azure

### DIFF
--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -67,6 +67,13 @@ function Install-SoftwarePackage
         Write-Error "The file '$Path' could not found"
         return        
     }
+
+    $pattern = '\\\\automatedlabsource[a-z]{6}.file.core.windows.net\\labsources'
+    if ((Test-Path -Path C:\WindowsAzure) -and $path -match $pattern) #Runnign on Azure VM?
+    {
+        $labSourcesDriveLetter = (Get-PSDrive | Where-Object DisplayRoot -Match $pattern)[0].Name #Sometimes, there are two drives, so we need to get the first one
+        $path = $path -replace $pattern, "$($labSourcesDriveLetter):"
+    }
         
     $start = Get-Date
     Write-Verbose -Message "Starting setup of '$Path' with the following command"
@@ -83,7 +90,7 @@ function Install-SoftwarePackage
             @(
                 "/I `"$Path`"", # Install this MSI
                 '/QN', # Quietly, without a UI
-                "/L*V `"$([System.IO.Path]::GetTempPath())$([System.IO.Path]::GetFileNameWithoutExtension($Path)).log`""     # Verbose output to this log
+                "/L*V `"$([System.IO.Path]::GetTempPath())$([System.IO.Path]::GetFileNameWithoutExtension($Path)).log`"" # Verbose output to this log
             )
         }
         else


### PR DESCRIPTION
## Description

When running on Azure the LabSources folder is accessed remotely which some installers don't like. Many of these cases can be solved by accessing the file via the mapped drive instead the UNC share.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab.common/develop before creating the PR.

## Type of change

- [ ] Bug fix  
- [x] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Installations for Exchange 2019 lab.