### PR TITLE
Calling 'C:\AL\AzureLabSources.ps1' if path on lab sources cannot be found

### DIFF
--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -31,6 +31,11 @@ function Install-SoftwarePackage
 
             [string]$WorkingDirectory
         )
+
+        if (-not ((Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
+        {
+            $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1
+        }
     
         $pInfo = New-Object -TypeName System.Diagnostics.ProcessStartInfo
         $pInfo.FileName = $Path
@@ -52,11 +57,14 @@ function Install-SoftwarePackage
         $p.WaitForExit()
         Write-Verbose -Message 'Process exited. Reading output'
 
-        $params = @{ Process = $p }
+        $params = @{
+            Process = $p
+            LabSourcesConnectOutput = $labSourcesConnectOutput
+        }
         if (-not $UseShellExecute)
         {
-            $params.Add('Output', $p.StandardOutput.ReadToEnd())
-            $params.Add('Error', $p.StandardError.ReadToEnd())
+            $params.Output = $p.StandardOutput.ReadToEnd()
+            $params.Error = $p.StandardError.ReadToEnd()
         }
         New-Object -TypeName PSObject -Property $params
     }

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -35,8 +35,12 @@ function Install-SoftwarePackage
         if (-not ((Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
         {
             $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1
+            if ($labSourcesConnectOutput.AlternativeLabSourcesPath)
+            {
+                $Path = $Path.Replace($labSourcesConnectOutput.LabSourcesPath, $labSourcesConnectOutput.AlternativeLabSourcesPath)
+            }
         }
-    
+
         $pInfo = New-Object -TypeName System.Diagnostics.ProcessStartInfo
         $pInfo.FileName = $Path
         if (-not [string]::IsNullOrWhiteSpace($WorkingDirectory)) { $pInfo.WorkingDirectory = $WorkingDirectory }


### PR DESCRIPTION
## Description

Sometimes, files on the Azure LabSources share cannot be found. Calling the file `C:\AL\AzureLabSources.ps1` fixes that. This workaround should be going to `AutomatedLab` and not to `AutomatedLab.Common`, however, calling `C:\AL\AzureLabSources.ps1` may be required also when running in a scheduled task. This is why this workaround needs to go into this module.

- [x] - I have tested my changes.  
- [x] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab.common/develop before creating the PR.

## Type of change

- [x] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Exchange 2019 deployment