### PR TITLE
Fixing if-condition

### DIFF
--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -33,7 +33,7 @@ function Install-SoftwarePackage
         )
 
         #if the path cannot be found and starts with \\automatedlabsources...
-        if ((-not (Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
+        if ((-not (Test-Path -Path $Path) -and $Path -match '\\\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
         {
             #we assume, the LabSources share was not mapped correctly and try again by calling 'C:\AL\AzureLabSources.ps1'
             $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -32,8 +32,10 @@ function Install-SoftwarePackage
             [string]$WorkingDirectory
         )
 
-        if (-not ((Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
+        #if the path cannot be found and starts with \\automatedlabsources...
+        if ((-not (Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
         {
+            #we assume, the LabSources share was not mapped correctly and try again by calling 'C:\AL\AzureLabSources.ps1'
             $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1
             if ($labSourcesConnectOutput.AlternativeLabSourcesPath)
             {

--- a/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
+++ b/AutomatedLab.Common/Common/Public/Install-SoftwarePackage.ps1
@@ -32,17 +32,6 @@ function Install-SoftwarePackage
             [string]$WorkingDirectory
         )
 
-        #if the path cannot be found and starts with \\automatedlabsources...
-        if ((-not (Test-Path -Path $Path) -and $Path -match '\\\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
-        {
-            #we assume, the LabSources share was not mapped correctly and try again by calling 'C:\AL\AzureLabSources.ps1'
-            $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1
-            if ($labSourcesConnectOutput.AlternativeLabSourcesPath)
-            {
-                $Path = $Path.Replace($labSourcesConnectOutput.LabSourcesPath, $labSourcesConnectOutput.AlternativeLabSourcesPath)
-            }
-        }
-
         $pInfo = New-Object -TypeName System.Diagnostics.ProcessStartInfo
         $pInfo.FileName = $Path
         if (-not [string]::IsNullOrWhiteSpace($WorkingDirectory)) { $pInfo.WorkingDirectory = $WorkingDirectory }
@@ -75,6 +64,17 @@ function Install-SoftwarePackage
         New-Object -TypeName PSObject -Property $params
     }
     #endregion New-InstallProcess
+
+    #if the path cannot be found and starts with \\automatedlabsources...
+    if ((-not (Test-Path -Path $Path) -and $Path -match '\\automatedlabsources[a-z]{5}\.file\.core\.windows\.net'))
+    {
+        #we assume, the LabSources share was not mapped correctly and try again by calling 'C:\AL\AzureLabSources.ps1'
+        $labSourcesConnectOutput = C:\AL\AzureLabSources.ps1 2> $null
+        if ($labSourcesConnectOutput.AlternativeLabSourcesPath)
+        {
+            $Path = $Path.Replace($labSourcesConnectOutput.LabSourcesPath, $labSourcesConnectOutput.AlternativeLabSourcesPath)
+        }
+    }
 
     if (-not (Test-Path -Path $Path -PathType Leaf))
     {


### PR DESCRIPTION
## Description

`C:\AL\AzureLabSources.ps1` should never be called in a Hyper-V machine. Fixed the if-statement so that we call it only when the path cannot be resolved and the path starts with `\\automatedlabsources...`.

This fixes AutomatedLab/AutomatedLab#1623.

- [x] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x] - The PR has a meaningful title.  
- [x] - I updated my fork/branch and have integrated all changes from AutomatedLab.common/develop before creating the PR.

## Type of change

- [x] Bug fix
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
Manual tests on a Azure and non-Azure machine.